### PR TITLE
Fix block offset calculation

### DIFF
--- a/dxt1.go
+++ b/dxt1.go
@@ -23,7 +23,7 @@ type Dxt1 struct {
 func NewDxt1(r image.Rectangle) *Dxt1 {
 	w, h := r.Dx(), r.Dy()
 	pix := make([]uint8, ((w+3)/4)*((h+3)/4)*8)
-	return &Dxt1{pix, (w+3)/4*8, r}
+	return &Dxt1{pix, (w + 3) / 4 * 8, r}
 }
 
 func (p *Dxt1) ColorModel() color.Model {
@@ -44,5 +44,5 @@ func (p *Dxt1) At(x, y int) color.Color {
 }
 
 func (p *Dxt1) BlockOffset(x, y int) int {
-	return p.Stride*(y/4) + (x / 4)
+	return p.Stride*(y/4) + ((x / 4) * 8)
 }

--- a/dxt3.go
+++ b/dxt3.go
@@ -22,7 +22,7 @@ type Dxt3 struct {
 func NewDxt3(r image.Rectangle) *Dxt3 {
 	w, h := r.Dx(), r.Dy()
 	pix := make([]uint8, ((w+3)/4)*((h+3)/4)*16)
-	return &Dxt3{pix, (w+3)/4*16, r}
+	return &Dxt3{pix, (w + 3) / 4 * 16, r}
 }
 
 func (p *Dxt3) ColorModel() color.Model {
@@ -43,5 +43,5 @@ func (p *Dxt3) At(x, y int) color.Color {
 }
 
 func (p *Dxt3) BlockOffset(x, y int) int {
-	return p.Stride*(y/4) + (x / 4)
+	return p.Stride*(y/4) + ((x / 4) * 16)
 }

--- a/dxt5.go
+++ b/dxt5.go
@@ -22,7 +22,7 @@ type Dxt5 struct {
 func NewDxt5(r image.Rectangle) *Dxt5 {
 	w, h := r.Dx(), r.Dy()
 	pix := make([]uint8, ((w+3)/4)*((h+3)/4)*16)
-	return &Dxt5{pix, (w+3)/4*16, r}
+	return &Dxt5{pix, (w + 3) / 4 * 16, r}
 }
 
 func (p *Dxt5) ColorModel() color.Model {
@@ -43,5 +43,5 @@ func (p *Dxt5) At(x, y int) color.Color {
 }
 
 func (p *Dxt5) BlockOffset(x, y int) int {
-	return p.Stride*(y/4) + (x / 4)
+	return p.Stride*(y/4) + ((x / 4) * 16)
 }


### PR DESCRIPTION
There currently is an error where each x coordinate is not multiplied by the block offset size, so only the first block gets read correctly and all others become corrupted. This PR fixes this issue.