### PR TITLE
Fix alpha calculation. Pass alpha to DXT3 and DXT5

### DIFF
--- a/dxt.go
+++ b/dxt.go
@@ -64,7 +64,7 @@ func ConvertDxt5BlockAt(pix []uint8, x, y int) (r, g, b, a uint32) {
 	bits := uint64(pix[2]) | uint64(pix[3])<<8 | uint64(pix[4])<<16
 	bits |= uint64(pix[5])<<24 | uint64(pix[6])<<32 | uint64(pix[7])<<40
 
-	code := bits >> (3 * ((uint8(y) * 4) + uint8(x)))
+	code := (bits >> ((y*4 + x) * 3)) & 7
 	switch code {
 	case 0:
 		a = alpha0

--- a/dxt3.go
+++ b/dxt3.go
@@ -26,7 +26,7 @@ func NewDxt3(r image.Rectangle) *Dxt3 {
 }
 
 func (p *Dxt3) ColorModel() color.Model {
-	return color.RGBAModel
+	return color.NRGBAModel
 }
 
 func (p *Dxt3) Bounds() image.Rectangle {
@@ -35,11 +35,11 @@ func (p *Dxt3) Bounds() image.Rectangle {
 
 func (p *Dxt3) At(x, y int) color.Color {
 	if !(image.Point{x, y}.In(p.Rect)) {
-		return color.RGBA{}
+		return color.NRGBA{}
 	}
 	i := p.BlockOffset(x, y)
-	r, g, b, _ := ConvertDxt3BlockAt(p.Pix[i:i+16], x%4, y%4)
-	return color.RGBA{uint8(r >> 8), uint8(g >> 8), uint8(b >> 8), 0xFF}
+	r, g, b, a := ConvertDxt3BlockAt(p.Pix[i:i+16], x%4, y%4)
+	return color.NRGBA{uint8(r >> 8), uint8(g >> 8), uint8(b >> 8), uint8(a >> 8)}
 }
 
 func (p *Dxt3) BlockOffset(x, y int) int {

--- a/dxt5.go
+++ b/dxt5.go
@@ -26,7 +26,7 @@ func NewDxt5(r image.Rectangle) *Dxt5 {
 }
 
 func (p *Dxt5) ColorModel() color.Model {
-	return color.RGBAModel
+	return color.NRGBAModel
 }
 
 func (p *Dxt5) Bounds() image.Rectangle {
@@ -35,11 +35,11 @@ func (p *Dxt5) Bounds() image.Rectangle {
 
 func (p *Dxt5) At(x, y int) color.Color {
 	if !(image.Point{x, y}.In(p.Rect)) {
-		return color.RGBA{}
+		return color.NRGBA{}
 	}
 	i := p.BlockOffset(x, y)
-	r, g, b, _ := ConvertDxt5BlockAt(p.Pix[i:i+16], x%4, y%4)
-	return color.RGBA{uint8(r >> 8), uint8(g >> 8), uint8(b >> 8), 0xFF}
+	r, g, b, a := ConvertDxt5BlockAt(p.Pix[i:i+16], x%4, y%4)
+	return color.NRGBA{uint8(r >> 8), uint8(g >> 8), uint8(b >> 8), uint8(a >> 8)}
 }
 
 func (p *Dxt5) BlockOffset(x, y int) int {


### PR DESCRIPTION
This PR contains 3 changes:

1. Pass down the actual alpha value for DXT3 and DXT5 to the produced pixel color. Currently it was hardcoded to 0xFF
2. Correct the code calculation to select the correct alpha value from the alpha table
3. Switch DXT3 and DXT5 to NRGBA, as the RGB values are not multiplied by the alpha